### PR TITLE
Fixed typos and switched to https://libvirt.org/ as hyperlink.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [![Travis CI](http://img.shields.io/travis/debops/ansible-libvirtd.svg?style=flat)](http://travis-ci.org/debops/ansible-libvirtd) [![test-suite](http://img.shields.io/badge/test--suite-ansible--libvirtd-blue.svg?style=flat)](https://github.com/debops/test-suite/tree/master/ansible-libvirtd/)  [![Ansible Galaxy](http://img.shields.io/badge/galaxy-debops.libvirtd-660198.svg?style=flat)](https://galaxy.ansible.com/list#/roles/4548)
 
-`debops.libvirtd` Ansible role manages the [libvirtd](http://libvirt.org/)
+The `debops.libvirtd` Ansible role manages the [libvirtd][libvirt]
 daemon on a virtualization host (server side). It will automatically
 install QEMU KVM support on any host that is not a KVM guest, to allow for
 easy deployment of KVM virtual machines.
 
 Configuration of `libvirtd` instance (local or remote) can be performed using
-`debops.libvirt` role, which uses `libvirt` API to manage the server.
+`debops.libvirt` role, which uses the `libvirt` API to manage the server.
+
+[libvirt]: https://libvirt.org/
 
 ### Installation
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,7 @@
 # .. envvar:: libvirtd_base_packages
 #
 # List of ``libvirtd`` packages which will be installed on all distribution
-# releases, unless overriden.
+# releases, unless overridden.
 libvirtd_base_packages: [ 'libvirt-daemon-system', 'libvirt-clients' ]
 
 
@@ -32,7 +32,7 @@ libvirtd_base_packages_map:
 libvirtd_kvm_packages: [ 'qemu-system-x86', 'qemu-kvm' ]
 
 
-# .. envvar:: libvirtd_network_packgages
+# .. envvar:: libvirtd_network_packages
 #
 # List of network-related packages to install with ``libvirtd``.
 libvirtd_network_packages: [ 'dnsmasq-base', 'bridge-utils', 'ebtables' ]
@@ -50,7 +50,7 @@ libvirtd_packages: []
 
 # .. envvar:: libvirtd_admins
 #
-# List of administrator accounts which should have access to libvirtd.
+# List of administrator accounts which should have access to ``libvirtd``.
 libvirtd_admins: [ '{{ ansible_ssh_user
                        if (ansible_ssh_user != "root")
                        else "" }}' ]

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -4,7 +4,7 @@ Getting started
 .. contents::
    :local:
 
-``debops.libvirtd`` role will install ``libvirtd`` along with virtualization
+The ``debops.libvirtd`` role will install ``libvirtd`` along with virtualization
 components required on the server.
 
 Configuration at the moment is very minimal - specified account will be granted
@@ -23,7 +23,7 @@ a host to ``[debops_libvirtd]`` group.
 Example playbook
 ----------------
 
-Here's an example playbook which uses ``debops.libvirtd`` role::
+Here's an example playbook which uses the ``debops.libvirtd`` role::
 
     ---
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -7,9 +7,9 @@ support on any host that is not a KVM guest, to allow for easy deployment of
 KVM virtual machines.
 
 Configuration of ``libvirtd`` instance (local or remote) can be performed using
-``debops.libvirt`` role, which uses ``libvirt`` API to manage the server.
+``debops.libvirt`` role, which uses the ``libvirt`` API to manage the server.
 
-.. _libvirtd: http://libvirt.org/
+.. _libvirtd: https://libvirt.org/
 
 Installation
 ~~~~~~~~~~~~

--- a/meta/ansigenome.yml
+++ b/meta/ansigenome.yml
@@ -17,11 +17,12 @@ ansigenome_info:
       github: 'drybjed'
 
   synopsis: |
-    `debops.libvirtd` Ansible role manages the [libvirtd](http://libvirt.org/)
+    The `debops.libvirtd` Ansible role manages the [libvirtd][libvirt]
     daemon on a virtualization host (server side). It will automatically
     install QEMU KVM support on any host that is not a KVM guest, to allow for
     easy deployment of KVM virtual machines.
-    
-    Configuration of `libvirtd` instance (local or remote) can be performed using
-    `debops.libvirt` role, which uses `libvirt` API to manage the server.
 
+    Configuration of `libvirtd` instance (local or remote) can be performed using
+    `debops.libvirt` role, which uses the `libvirt` API to manage the server.
+
+    [libvirt]: https://libvirt.org/

--- a/templates/etc/libvirt/libvirt.conf.j2
+++ b/templates/etc/libvirt/libvirt.conf.j2
@@ -24,4 +24,3 @@ uri_aliases = [
 {% if libvirtd_uri|d() %}
 uri_default = "{{ libvirtd_connections[libvirtd_uri] }}"
 {% endif %}
-


### PR DESCRIPTION
* Removed last empty line in template.
* Changes related to https://github.com/debops/ansible-libvirt/pull/2