### PR TITLE
Install qemu-utils package.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ libvirtd__base_packages_map:
 libvirtd__kvm_packages:
   - 'qemu-system-x86'
   - 'qemu-kvm'
+  - 'qemu-utils'
 
 
 # .. envvar:: libvirtd__network_packages


### PR DESCRIPTION
qemu-utils is needed to create non-raw images, like qcow2 which
isvirt-manager's default image type.