### PR TITLE
Proposal for another way to detect the group name used by libvirtd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,8 +72,8 @@ libvirtd__admins: [ '{{ (ansible_ssh_user
 #
 # Mapping of default UNIX access group on different distributions.
 libvirtd__group_map:
-  'Debian': 'libvirt'
-  'Ubuntu': 'libvirtd'
+  - 'libvirt'
+  - 'libvirtd'
                                                                    # ]]]
                                                                    # ]]]
 # libvirtd connection URI [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -63,7 +63,7 @@ libvirtd__packages: []
 #
 # List of administrator accounts which should have access to :program:`libvirtd`.
 libvirtd__admins: [ '{{ (ansible_ssh_user
-                        if (ansible_ssh_user | d()) else ansible_user | d()) }}' ]
+                        if (ansible_ssh_user | d()) else ansible_user | d(lookup("env", "USER"))) }}' ]
 
                                                                    # ]]]
 # .. envvar:: libvirtd__group_map [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ libvirtd__base_packages_map:
   'wheezy':  [ 'libvirt-bin' ]
   'precise': [ 'libvirt-bin' ]
   'trusty':  [ 'libvirt-bin' ]
+  'xenial':  [ 'libvirt-bin' ]
 
                                                                    # ]]]
 # .. envvar:: libvirtd__kvm_packages [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,8 @@ libvirtd__packages: []
 # .. envvar:: libvirtd__admins [[[
 #
 # List of administrator accounts which should have access to :program:`libvirtd`.
-libvirtd__admins: [ '{{ ansible_ssh_user | d(ansible_user) }}' ]
+libvirtd__admins: [ '{{ (ansible_ssh_user
+                        if (ansible_ssh_user | d()) else ansible_user | d()) }}' ]
 
                                                                    # ]]]
 # .. envvar:: libvirtd__group_map [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,10 +62,7 @@ libvirtd__packages: []
 # .. envvar:: libvirtd__admins [[[
 #
 # List of administrator accounts which should have access to :program:`libvirtd`.
-libvirtd__admins: [ '{{ (ansible_ssh_user
-                        if (ansible_ssh_user | d() and
-                            ansible_ssh_user != "root")
-                        else lookup("env", "USER")) }}' ]
+libvirtd__admins: [ '{{ ansible_ssh_user | d(ansible_user) }}' ]
 
                                                                    # ]]]
 # .. envvar:: libvirtd__group_map [[[

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,10 +24,14 @@
     group: 'root'
     mode: '0644'
 
+- name: Get list of groups
+  command: cut -d ":" -f 1 /etc/group
+  register: libvirt__register_groups
+
 - name: Add administrators to libvirt system group
   user:
     name: '{{ item }}'
-    groups: '{{ libvirtd__group_map[ansible_distribution] }}'
+    groups: "{{ libvirt__register_groups.stdout.split('\n') | intersect(libvirtd__group_map) | join(',') }}"
     append: True
   with_items: '{{ libvirtd__admins }}'
   when: libvirtd__admins|d()

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,9 @@
 - name: Get list of groups
   command: cut -d ":" -f 1 /etc/group
   register: libvirt__register_groups
-
+  changed_when: False
+  always_run: True
+  
 - name: Add administrators to libvirt system group
   user:
     name: '{{ item }}'


### PR DESCRIPTION
Starting Ubuntu 16.10 the libvirtd group name changes to libvirt. As a result, the step where ansible_ssh_user is added to that group breaks. This fixes the issue and changes the way the group name is detected.