### PR TITLE
Support for enabling Kernel Samepage Merging (KSM)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -104,6 +104,27 @@ libvirtd__connections:
 libvirtd__uri: 'localhost'
                                                                    # ]]]
                                                                    # ]]]
+# KSM (Kernel Samepage Merging) configuration [[[
+# -----------------------------------------------
+
+# .. envvar:: libvirtd__ksm_enable [[[
+#
+# Wheter to enable KSM
+libvirtd__ksm_enabled: False
+
+                                                                   # ]]]
+# .. envvar:: libvirtd__ksm_sleep_milisecs [[[
+#
+# How long to sleep in between page scans
+libvirtd__ksm_sleep_milisecs: 20
+
+                                                                   # ]]]
+# .. envvar:: libvirtd__ksm_pages_to_scan [[[
+#
+# How many pages to scan in one run
+libvirtd__ksm_pages_to_scan: 100
+                                                                   # ]]]
+                                                                   # ]]]
 # Role-dependent configuration [[[
 # --------------------------------
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: 'Restart sysfsutils'
+  service:
+    name: 'sysfsutils'
+    state: 'restarted'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
   with_flattened:
     - '{{ libvirtd__network_packages }}'
     - '{{ libvirtd__packages }}'
-    - [ 'gawk', 'virt-top', 'netcat-openbsd', 'pm-utils' ]
+    - [ 'gawk', 'virt-top', 'netcat-openbsd', 'pm-utils', 'sysfsutils' ]
     - [ '{{ libvirtd__base_packages_map[ansible_distribution_release]
             if (ansible_distribution_release in libvirtd__base_packages_map.keys())
             else libvirtd__base_packages }}' ]
@@ -32,3 +32,11 @@
   with_items: '{{ libvirtd__admins }}'
   when: libvirtd__admins|d()
 
+- name: Add KSM sysfsutils configuration
+  template:
+    src: 'etc/sysfs.d/ksm.conf'
+    dest: '/etc/sysfs.d/ksm.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: 'Restart sysfsutils'

--- a/templates/etc/sysfs.d/ksm.conf
+++ b/templates/etc/sysfs.d/ksm.conf
@@ -1,0 +1,8 @@
+# Enable KSM
+kernel/mm/ksm/run = {{ '1' if libvirtd__ksm_enabled|bool else '0' }}
+
+# How long to sleep between scans
+kernel/mm/ksm/sleep_millisecs = {{ libvirtd__ksm_sleep_milisecs }}
+
+# How many pages to scan in one run
+kernel/mm/ksm/pages_to_scan = {{ libvirtd__ksm_pages_to_scan }}


### PR DESCRIPTION
This can reduce memory usage a lot when running many similar guests.
It's enabled by default but can be disabled.