### PR TITLE
Rework 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,7 +47,7 @@ Added
   Currently plain "libvirt" and OpenNebula environments are supported.
   [drybjed_]
 
-- Add the ``debops.libvirtd_qemu`` role to the example playbook. [drybjed_]
+- Add the debops.libvirtd_qemu_ role to the example playbook. [drybjed_]
 
 Changed
 ~~~~~~~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,7 +213,7 @@ libvirtd__original_configuration:
 
   - name: 'mdns_adv' # [[[
     comment: |
-      Flag toggling mDNS advertizement of the libvirt service.
+      Flag toggling mDNS advertisement of the libvirt service.
 
       Alternatively can disable for all services on a host by
       stopping the Avahi daemon
@@ -226,7 +226,7 @@ libvirtd__original_configuration:
 
   - name: 'mdns_name' # [[[
     comment: |
-      Override the default mDNS advertizement name. This must be
+      Override the default mDNS advertisement name. This must be
       unique on the immediate broadcast network.
 
       The default is "Virtualization Host HOSTNAME", where HOSTNAME
@@ -890,19 +890,19 @@ libvirtd__configuration_sections:
 
 # .. envvar:: libvirtd__ksm_enable [[[
 #
-# Wheter to enable KSM
+# Whether to enable KSM.
 libvirtd__ksm_enabled: False
 
                                                                    # ]]]
 # .. envvar:: libvirtd__ksm_sleep_milisecs [[[
 #
-# How long to sleep in between page scans
+# How long to sleep in between page scans.
 libvirtd__ksm_sleep_milisecs: 20
 
                                                                    # ]]]
 # .. envvar:: libvirtd__ksm_pages_to_scan [[[
 #
-# How many pages to scan in one run
+# How many pages to scan in one run.
 libvirtd__ksm_pages_to_scan: 100
                                                                    # ]]]
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,7 @@ libvirtd__misc_packages:
 libvirtd__packages: []
 
                                                                    # ]]]
-# .. envvar::libvirtd__version [[[
+# .. envvar:: libvirtd__version [[[
 #
 # The version of the :command:`libvirtd` daemon exposed as a convenient
 # variable for conditional checks.
@@ -204,7 +204,7 @@ libvirtd__original_configuration:
       interfaces. This can be a numeric IPv4/6 address, or hostname
 
       If the libvirtd service is started in parallel with network
-      startup (e.g. with systemd), binding to addresses other than
+      startup (e. g. with systemd), binding to addresses other than
       the wildcards (0.0.0.0/::) might not be available yet.
     value: '192.168.0.1'
     section: 'network'
@@ -615,7 +615,7 @@ libvirtd__original_configuration:
 
           where name is a string which is matched against the category
           given in the VIR_LOG_INIT() at the top of each libvirt source
-          file, e.g., "remote", "qemu", or "util.json" (the name in the
+          file, e. g., "remote", "qemu", or "util.json" (the name in the
           filter can be a substring of the full category name, in order
           to match multiple similar categories), the optional "+" prefix
           tells libvirt to log stack trace for each message matching
@@ -630,7 +630,7 @@ libvirtd__original_configuration:
       Multiple filters can be defined in a single @filters, they just need to be
       separated by spaces.
 
-      e.g. to only get warning or errors from the remote layer and only errors
+      e. g. to only get warning or errors from the remote layer and only errors
       from the event layer:
     value: '3:remote 4:event'
     section: 'log'
@@ -657,7 +657,7 @@ libvirtd__original_configuration:
         4: ERROR
 
       Multiple outputs can be defined, they just need to be separated by spaces.
-      e.g. to log all warnings and errors to syslog under the libvirtd ident:
+      e. g. to log all warnings and errors to syslog under the libvirtd ident:
     value: '3:syslog:libvirtd'
     section: 'log'
     state: 'comment'
@@ -888,7 +888,7 @@ libvirtd__configuration_sections:
 # KSM (Kernel Samepage Merging) configuration [[[
 # -----------------------------------------------
 
-# .. envvar:: libvirtd__ksm_enable [[[
+# .. envvar:: libvirtd__ksm_enabled [[[
 #
 # Whether to enable KSM.
 libvirtd__ksm_enabled: False
@@ -911,7 +911,7 @@ libvirtd__ksm_pages_to_scan: 100
 
 # .. envvar:: libvirtd__apt_preferences__dependent_list [[[
 #
-# Configuration for the ``debops.apt_preferences`` role.
+# Configuration for the debops.apt_preferences_ role.
 libvirtd__apt_preferences__dependent_list:
 
   - packages: [ 'libvirt0', 'libvirt0-dbg', 'libvirt-*',
@@ -924,7 +924,7 @@ libvirtd__apt_preferences__dependent_list:
                                                                    # ]]]
 # .. envvar:: libvirtd__ferm__dependent_rules [[[
 #
-# Configuration for ``debops.ferm`` firewall.
+# Configuration for debops.ferm_ firewall.
 libvirtd__ferm__dependent_rules:
 
   - type: 'custom'

--- a/docs/defaults-detailed.rst
+++ b/docs/defaults-detailed.rst
@@ -131,7 +131,7 @@ of the list is a YAML dictionary with specific parameters:
   ``section`` parameter. Should be short and recognizable.
 
 ``title``
-  Required. A shor description of the given configuration file section which
+  Required. A short description of the given configuration file section which
   will be added as a header.
 
 ``comment``

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -41,9 +41,9 @@ Ansible tags
 ------------
 
 You can use Ansible ``--tags`` or ``--skip-tags`` parameters to limit what
-tasks are performed during Ansible run. This can be used after host is first
+tasks are performed during Ansible run. This can be used after a host was first
 configured to speed up playbook execution, when you are sure that most of the
-configuration has not been changed.
+configuration is already in the desired state.
 
 Available role tags:
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,13 +1,15 @@
 Introduction
 ============
 
+.. include:: includes/all.rst
+
 ``debops.libvirtd`` Ansible role manages the `libvirtd`_ daemon on
 a virtualization host (server side). It will automatically install QEMU KVM
 support on any host that is not a KVM guest, to allow for easy deployment of
 KVM virtual machines.
 
 Configuration of :program:`libvirtd` instance (local or remote) can be performed using
-``debops.libvirt`` role, which uses the ``libvirt`` API to manage the server.
+debops.libvirt_ role, which uses the ``libvirt`` API to manage the server.
 
 .. _libvirtd: https://libvirt.org/
 


### PR DESCRIPTION
Related to: #14
Status: WIP
Test failing reason: Outside of scope of this PR. `debops.libvirtd_qemu` not yet available (ref: https://github.com/debops/ansible-libvirtd/pull/14#discussion_r118990132)

The test suite should probably be extended to include yaml4rst (which I have found to be where solid btw :wink: ) to catch such low hanging fruits before you make a release. @drybjed Maybe this would be a great opportunity for you to get to know and like it :)